### PR TITLE
require bcryptjs instead of bcrypt for compatibility

### DIFF
--- a/models/pilot.js
+++ b/models/pilot.js
@@ -2,7 +2,7 @@
 
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const bcrypt = require('bcrypt');
+const bcrypt = require('bcryptjs');
 const Ride = require('./ride');
 
 // Use native promises.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "bcrypt": "^1.0.2",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.17.2",
     "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-beta.2",


### PR DESCRIPTION
when running `npm install` on OSX 10.12.5 

npm ERR! Failed at the bcrypt@1.0.2 install script.
...
node-pre-gyp ERR! build error

switching to bcryptjs and install works :) 