### PR TITLE
Update prefill params & prefill business name

### DIFF
--- a/server/routes/pilots/stripe.js
+++ b/server/routes/pilots/stripe.js
@@ -32,9 +32,10 @@ router.get('/authorize', pilotRequired, (req, res) => {
   // and `phone` in the query parameters for them to be autofilled.
   parameters = Object.assign(parameters, {
     'stripe_user[business_type]': req.user.type || 'individual',
-    first_name: req.user.firstName || undefined,
-    last_name: req.user.lastName || undefined,
-    email: req.user.email
+    'stripe_user[first_name]': req.user.firstName || undefined,
+    'stripe_user[last_name]': req.user.lastName || undefined,
+    'stripe_user[email]': req.user.email,
+    'stripe_user[business_name]': req.user.businessName || undefined,
   });
   // Redirect to Stripe to start the Connect onboarding.
   res.redirect(config.stripe.authorizeUri + '?' + querystring.stringify(parameters));


### PR DESCRIPTION
This adds a parameter to prefill the business name when onboarding as a business.

I've also updated the names of the other prefill parameters. Although passing `first_name`, `last_name` and `email` will still work for now for backwards compatibility, the official way to prefillt these fields is with the `stripe_user[...]` parameters [as shown in the OAuth Reference docs](https://stripe.com/docs/connect/oauth-reference).