### PR TITLE
Aligned subtitles to the left 

### DIFF
--- a/server/public/stylesheets/rocketrides.css
+++ b/server/public/stylesheets/rocketrides.css
@@ -546,7 +546,7 @@ form a.button {
 
 .features section {
   flex: 1;
-  align-items: left;
+  align-items: flex-start;
   padding: 90px 0 0;
   margin: 20px 40px 0 0;
   background-position: 0 20px;
@@ -716,7 +716,7 @@ form a.button {
   width: 100%;
   max-width: 800px;
   margin: 30px 0;
-  align-items: left;
+  align-items: flex-start;
   animation: slide-in-vertical 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000) both 0.55s;
 }
 


### PR DESCRIPTION
Fixed a small visual bug where some of our subtitles were misaligned. 
<img width="940" alt="screen shot 2018-05-02 at 3 04 46 pm" src="https://user-images.githubusercontent.com/37303704/39593792-b0d41248-4ebf-11e8-96f0-d0dec6dda394.png">
