### PR TITLE
Don't make payouts instant in the RR dashboard

### DIFF
--- a/server/routes/pilots/stripe.js
+++ b/server/routes/pilots/stripe.js
@@ -111,7 +111,6 @@ router.post('/payout', pilotRequired, async (req, res) => {
     const { amount, currency } = balance.available[0];
     // Create the instant payout.
     const payout = await stripe.payouts.create({
-      method: 'instant',
       amount: amount,
       currency: currency,
       statement_descriptor: config.appName


### PR DESCRIPTION
This is currently a bug if the user has a bank_account as their external account