### PR TITLE
Migrate from Swift 3 to 5 (fixes #27)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,10 +6,15 @@ DEPENDENCIES:
   - Alamofire
   - Stripe
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Stripe
+
 SPEC CHECKSUMS:
   Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
   Stripe: 898f83a95d72180c6eb4acd65b2ae6158fc6a8bd
 
 PODFILE CHECKSUM: df01c2ba3d529638d327c083cdf54b9821b82a0c
 
-COCOAPODS: 1.3.0
+COCOAPODS: 1.7.3

--- a/ios/RocketRides.xcodeproj/project.pbxproj
+++ b/ios/RocketRides.xcodeproj/project.pbxproj
@@ -166,7 +166,6 @@
 				7A1BBCCE1CF7B8E3004B1751 /* Frameworks */,
 				7A1BBCCF1CF7B8E3004B1751 /* Resources */,
 				7CA9B9BE312F9CE3DE95D784 /* [CP] Embed Pods Frameworks */,
-				638F23D17F483D5D060FE6A3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -189,7 +188,7 @@
 				TargetAttributes = {
 					7A1BBCD01CF7B8E3004B1751 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplePay = {
@@ -204,6 +203,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -231,28 +231,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		638F23D17F483D5D060FE6A3 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7CA9B9BE312F9CE3DE95D784 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Stripe/Stripe.framework",
 			);
@@ -263,7 +248,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D13DD1FA3F52518D33616A20 /* [CP] Check Pods Manifest.lock */ = {
@@ -428,6 +413,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -446,6 +432,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;

--- a/ios/RocketRides/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/RocketRides/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -41,6 +41,11 @@
       "idiom" : "iphone",
       "filename" : "AppIcon@3x.png",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/ios/RocketRides/LocationSearchViewController.swift
+++ b/ios/RocketRides/LocationSearchViewController.swift
@@ -33,7 +33,7 @@ class LocationSearchViewController: UIViewController, UITableViewDataSource, UIT
 
         let searchBarFont = UIFont.systemFont(ofSize: 17.0)
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).font = searchBarFont
-        UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).defaultTextAttributes = [NSFontAttributeName: searchBarFont, NSForegroundColorAttributeName: UIColor.riderDarkBlueColor]
+        UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).defaultTextAttributes = [NSAttributedString.Key.font: searchBarFont, NSAttributedString.Key.foregroundColor: UIColor.riderDarkBlueColor]
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -135,14 +135,14 @@ class LocationSearchViewController: UIViewController, UITableViewDataSource, UIT
         }
 
         // Setup search request
-        let searchRequest = MKLocalSearchRequest()
+        let searchRequest = MKLocalSearch.Request()
 
         searchRequest.naturalLanguageQuery = searchQuery
 
         if let centerCoordinate = delegate?.searchCenterCoordinate(for: self) {
             // Attach region to search request
             let distance: CLLocationDistance = 100 // 100km
-            searchRequest.region = MKCoordinateRegionMakeWithDistance(centerCoordinate, distance, distance)
+            searchRequest.region = MKCoordinateRegion.init(center: centerCoordinate, latitudinalMeters: distance, longitudinalMeters: distance)
         }
 
         // Perform new search request

--- a/ios/RocketRides/RideRequestViewController.swift
+++ b/ios/RocketRides/RideRequestViewController.swift
@@ -189,13 +189,13 @@ class RideRequestViewController: UIViewController, STPPaymentContextDelegate, Lo
             let centerCoordinate = CLLocationCoordinate2D(latitude: centerLatitude,longitude: centerLongitude)
             let distance = destinationLocation.distance(from: pickupLocation)
 
-            let region = MKCoordinateRegionMakeWithDistance(centerCoordinate, 1.5 * distance, 1.5 * distance)
+            let region = MKCoordinateRegion.init(center: centerCoordinate, latitudinalMeters: 1.5 * distance, longitudinalMeters: 1.5 * distance)
             mapView.setRegion(region, animated: true)
         }
         else if let singleLocation = pickupPlacemark?.location ?? destinationPlacemark?.location {
             // Show either pickup or destination location in map
             let distance: CLLocationDistance = 1000.0 // 1km
-            let region = MKCoordinateRegionMakeWithDistance(singleLocation.coordinate, distance, distance)
+            let region = MKCoordinateRegion.init(center: singleLocation.coordinate, latitudinalMeters: distance, longitudinalMeters: distance)
             mapView.setRegion(region, animated: true)
         }
         else {
@@ -219,7 +219,7 @@ class RideRequestViewController: UIViewController, STPPaymentContextDelegate, Lo
         // Show rocket path in map view
         if let pickupCoordinate = pickupPlacemark?.coordinate, let destinationCoordinate = destinationPlacemark?.coordinate {
             let rocketPathOverlay = RocketPathOverlay(start: pickupCoordinate, end: destinationCoordinate)
-            mapView.add(rocketPathOverlay, level: .aboveLabels)
+            mapView.addOverlay(rocketPathOverlay, level: .aboveLabels)
         }
     }
 
@@ -342,7 +342,7 @@ class RideRequestViewController: UIViewController, STPPaymentContextDelegate, Lo
         func moveToNextPoint() {
             // Move annotation to latest map point
             let mapPoint = rocketPathMapPoints[currentMapPointIdx]
-            rocketRiderAnnotation.coordinate = MKCoordinateForMapPoint(mapPoint)
+            rocketRiderAnnotation.coordinate = mapPoint.coordinate;
 
             // Iterate to next map point
             currentMapPointIdx += 1

--- a/ios/RocketRides/RocketPathOverlay.swift
+++ b/ios/RocketRides/RocketPathOverlay.swift
@@ -19,7 +19,7 @@ class RocketPathOverlay: NSObject, MKOverlay {
         let centerX = boundingMapRect.origin.x + (boundingMapRect.size.width / 2.0)
         let centerY = boundingMapRect.origin.y + (boundingMapRect.size.height / 2.0)
 
-        return MKCoordinateForMapPoint(MKMapPoint(x: centerX, y: centerY))
+        return MKMapPoint(x: centerX, y: centerY).coordinate
     }
 
     var boundingMapRect: MKMapRect {
@@ -28,13 +28,13 @@ class RocketPathOverlay: NSObject, MKOverlay {
         let rect = MKMapRect(origin: origin, size: size)
 
         // Increase rect to accommodate rocket path arc
-        return MKMapRectInset(rect, -size.width, -size.height)
+        return rect.insetBy(dx: -size.width, dy: -size.height)
     }
 
 
     init(start: CLLocationCoordinate2D, end: CLLocationCoordinate2D) {
-        self.startPoint = MKMapPointForCoordinate(start)
-        self.endPoint = MKMapPointForCoordinate(end)
+        self.startPoint = MKMapPoint.init(start)
+        self.endPoint = MKMapPoint.init(end)
     }
 
 }


### PR DESCRIPTION
The app no longer builds in the latest version of Xcode (10.2) because it's written in Swift 3 (#27).

This PR is the outcome of going through the migration process:
* Download Xcode 10.1 (last version capable of automatic 3 -> 4 migration) from https://developer.apple.com/download/more/
* `Edit > Convert... > To Latest 
   * For 3 to 4, then 4 to 4.2, and finally 4.2 to 5
   * Chose "Minimize Inference" (https://useyourloaf.com/blog/objc-warnings-upgrading-to-swift-4/)

This was mostly uneventful except for a hiccup in setting text attributes when one migration added:

```
+ // Helper function inserted by Swift 4.2 migrator.
+ fileprivate func convertToNSAttributedStringKeyDictionary(_ input: [String: Any]) -> [NSAttributedString.Key: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map { key, value in (NSAttributedString.Key(rawValue: key), value)})
+ }
```

but was made redundant in a later version (https://stackoverflow.com/questions/46314661/swift-4-conversion-error-nsattributedstringkey-any). I deleted the helper function and just initialized the NSAttributedStringKeyDictionary inline.