### PR TITLE
Updates app to use Swift 4.2 (and other modernizations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To integrate Stripe Connect in your own app, check out these two files in partic
 
 ### Requirements
 
-You'll need a Stripe account to manage pilot onboarding and payments. [Sign up for free](https://dashboard.stripe.com/register), then [enable Connect](https://dashboard.stripe.com/account/applications/settings) by filling in your Platform Settings. In the Development section, take note of your `client_id`, and enter the following in the Redirect URIs field: `http://localhost:3000/pilots/stripe/token`.
+You'll need a Stripe account to manage pilot onboarding and payments. [Sign up for free](https://dashboard.stripe.com/register), then [enable Connect](https://dashboard.stripe.com/account/applications/settings) by filling in your Platform Settings. In the Development section, enter the following in the Redirect URIs field: `http://localhost:3000/pilots/stripe/token`.
 
 For Instant Payouts to work, you'll need to [turn off automatic payouts](https://dashboard.stripe.com/account/payouts) in your settings.
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,20 @@
 PODS:
-  - Alamofire (4.5.0)
-  - Stripe (11.2.0)
+  - Alamofire (4.8.2)
+  - Stripe (16.0.6)
 
 DEPENDENCIES:
   - Alamofire
   - Stripe
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Stripe
+
 SPEC CHECKSUMS:
-  Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
-  Stripe: 898f83a95d72180c6eb4acd65b2ae6158fc6a8bd
+  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
+  Stripe: bbfdfb44bcc604bd3d29771f80d5d72710301fe3
 
 PODFILE CHECKSUM: df01c2ba3d529638d327c083cdf54b9821b82a0c
 
-COCOAPODS: 1.3.0
+COCOAPODS: 1.7.5

--- a/ios/RocketRides.xcodeproj/project.pbxproj
+++ b/ios/RocketRides.xcodeproj/project.pbxproj
@@ -166,7 +166,6 @@
 				7A1BBCCE1CF7B8E3004B1751 /* Frameworks */,
 				7A1BBCCF1CF7B8E3004B1751 /* Resources */,
 				7CA9B9BE312F9CE3DE95D784 /* [CP] Embed Pods Frameworks */,
-				638F23D17F483D5D060FE6A3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -231,28 +230,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		638F23D17F483D5D060FE6A3 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7CA9B9BE312F9CE3DE95D784 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Stripe/Stripe.framework",
 			);
@@ -263,7 +247,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RocketRides/Pods-RocketRides-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D13DD1FA3F52518D33616A20 /* [CP] Check Pods Manifest.lock */ = {
@@ -428,6 +412,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -446,6 +431,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;

--- a/ios/RocketRides.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RocketRides.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/RocketRides/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/RocketRides/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -41,6 +41,11 @@
       "idiom" : "iphone",
       "filename" : "AppIcon@3x.png",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/ios/RocketRides/Base.lproj/Main.storyboard
+++ b/ios/RocketRides/Base.lproj/Main.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="HGy-iL-ZIS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="HGy-iL-ZIS">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -36,7 +34,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="88"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="leV-o4-EIf">
-                                                <rect key="frame" x="0.0" y="0.0" width="398" height="43.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="398" height="43.666666666666664"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="20" maxY="0.0"/>
@@ -51,10 +49,10 @@
                                                 </connections>
                                             </button>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Tnu-CT-LWn" userLabel="Stack View">
-                                                <rect key="frame" x="0.0" y="44.666666666666679" width="398" height="43.333333333333321"/>
+                                                <rect key="frame" x="0.0" y="44.666666666666671" width="398" height="43.333333333333329"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yhc-bV-FEC">
-                                                        <rect key="frame" x="0.0" y="0.0" width="198.66666666666666" height="43.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="198.66666666666666" height="43.333333333333336"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="20" maxY="0.0"/>
@@ -69,7 +67,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EUP-nE-8zY" userLabel="Price Button">
-                                                        <rect key="frame" x="199.66666666666663" y="0.0" width="198.33333333333337" height="43.333333333333329"/>
+                                                        <rect key="frame" x="199.66666666666663" y="0.0" width="198.33333333333337" height="43.333333333333336"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="20" maxY="0.0"/>
@@ -108,7 +106,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="198.66666666666666" height="88"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Pilot" translatesAutoresizingMaskIntoConstraints="NO" id="IIG-7N-WCN">
-                                                        <rect key="frame" x="87.666666666666671" y="14" width="24" height="24"/>
+                                                        <rect key="frame" x="87.333333333333329" y="14" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="IIG-7N-WCN" secondAttribute="height" multiplier="48:43" id="1P7-gD-uNT"/>
                                                             <constraint firstAttribute="height" constant="48" id="6Lc-8K-Ko8"/>
@@ -131,13 +129,13 @@
                                                         </variation>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Romain Huet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zbt-zw-aq4" userLabel="Name">
-                                                        <rect key="frame" x="55" y="44" width="88" height="18"/>
+                                                        <rect key="frame" x="55.333333333333343" y="44" width="88" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <color key="textColor" red="0.19607843137254902" green="0.19215686274509802" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Stars" translatesAutoresizingMaskIntoConstraints="NO" id="7hj-1O-553">
-                                                        <rect key="frame" x="64.666666666666657" y="64" width="69.999999999999972" height="12"/>
+                                                        <rect key="frame" x="64.333333333333329" y="64" width="69.999999999999986" height="12"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="12" id="3z9-Le-1Ha"/>
                                                             <constraint firstAttribute="width" secondItem="7hj-1O-553" secondAttribute="height" multiplier="70:12" id="70O-RV-uep"/>
@@ -164,7 +162,7 @@
                                                 <rect key="frame" x="199.66666666666663" y="0.0" width="198.33333333333337" height="88"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Vehicle" translatesAutoresizingMaskIntoConstraints="NO" id="3B6-Lp-Dpe">
-                                                        <rect key="frame" x="75.000000000000028" y="16" width="47.666666666666629" height="20"/>
+                                                        <rect key="frame" x="75.333333333333343" y="16" width="47.333333333333343" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="48" id="9nZ-1Y-uOa"/>
                                                             <constraint firstAttribute="width" constant="48" id="PUA-4r-QW7"/>
@@ -187,13 +185,13 @@
                                                         </variation>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lightspeed 3000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8C4-qD-iLF" userLabel="Model">
-                                                        <rect key="frame" x="40.333333333333343" y="44.666666666666629" width="117.66666666666669" height="18"/>
+                                                        <rect key="frame" x="40.33333333333335" y="44.333333333333371" width="117.66666666666669" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <color key="textColor" red="0.1960784314" green="0.19215686269999999" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FUTURE 7" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w1c-vZ-laS" userLabel="License">
-                                                        <rect key="frame" x="68.000000000000028" y="62.666666666666629" width="62" height="15.666666666666742"/>
+                                                        <rect key="frame" x="68.333333333333343" y="62.333333333333364" width="61.666666666666657" height="15.666666666666664"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <color key="textColor" red="0.52941176470588236" green="0.59607843137254901" blue="0.6705882352941176" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -291,7 +289,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" searchBarStyle="prominent" placeholder="Enter a place or address" showsCancelButton="YES" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Xf-bi-GsJ">
-                                <rect key="frame" x="0.0" y="20" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="haV-aN-W99"/>
@@ -304,14 +302,14 @@
                                 </connections>
                             </searchBar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8d1-bp-e0z" userLabel="Separator View">
-                                <rect key="frame" x="0.0" y="64" width="414" height="1"/>
+                                <rect key="frame" x="0.0" y="72" width="414" height="1"/>
                                 <color key="backgroundColor" red="0.9137254901960784" green="0.93333333333333335" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="CoU-kK-dNm"/>
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="56" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="RmF-vH-boq">
-                                <rect key="frame" x="0.0" y="65" width="414" height="671"/>
+                                <rect key="frame" x="0.0" y="73" width="414" height="663"/>
                                 <color key="backgroundColor" red="0.96470588235294119" green="0.97647058823529409" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="separatorColor" red="0.9137254901960784" green="0.93333333333333335" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
@@ -319,28 +317,30 @@
                                         <rect key="frame" x="0.0" y="28" width="414" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aQv-B9-Xxu" id="lb4-Zm-ik4">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Location" translatesAutoresizingMaskIntoConstraints="NO" id="CLD-RQ-wk4">
-                                                    <rect key="frame" x="16" y="17" width="12" height="22"/>
+                                                    <rect key="frame" x="28" y="17" width="12" height="22"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4W4-8a-KK6" userLabel="Name">
-                                                    <rect key="frame" x="37" y="8" width="45" height="21"/>
+                                                    <rect key="frame" x="49" y="11" width="45" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.19607843137254902" green="0.19215686274509802" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Locality" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sm2-7i-u8P">
-                                                    <rect key="frame" x="37" y="31" width="50" height="17"/>
+                                                    <rect key="frame" x="49" y="34" width="50" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.52941176470588236" green="0.59607843137254901" blue="0.6705882352941176" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sm2-7i-u8P" secondAttribute="trailing" constant="20" symbolic="YES" id="P0G-0A-JZE"/>
                                                 <constraint firstItem="4W4-8a-KK6" firstAttribute="leading" secondItem="sm2-7i-u8P" secondAttribute="leading" id="SLL-aX-C05"/>
                                                 <constraint firstItem="4W4-8a-KK6" firstAttribute="top" secondItem="lb4-Zm-ik4" secondAttribute="topMargin" id="VNM-1G-BDU"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4W4-8a-KK6" secondAttribute="trailing" constant="20" symbolic="YES" id="YR0-cL-TiN"/>
                                                 <constraint firstItem="CLD-RQ-wk4" firstAttribute="centerY" secondItem="lb4-Zm-ik4" secondAttribute="centerY" id="b9R-lT-qaK"/>
                                                 <constraint firstItem="4W4-8a-KK6" firstAttribute="leading" secondItem="CLD-RQ-wk4" secondAttribute="trailing" constant="9" id="ipu-wv-fgm"/>
                                                 <constraint firstItem="CLD-RQ-wk4" firstAttribute="leading" secondItem="lb4-Zm-ik4" secondAttribute="leadingMargin" constant="8" id="ooV-4C-dXv"/>
@@ -365,7 +365,7 @@
                             <constraint firstItem="8d1-bp-e0z" firstAttribute="top" secondItem="2Xf-bi-GsJ" secondAttribute="bottom" id="4Ju-3B-Ec6"/>
                             <constraint firstItem="cei-6e-Wi8" firstAttribute="top" secondItem="RmF-vH-boq" secondAttribute="bottom" id="4t7-Mt-hKv"/>
                             <constraint firstAttribute="trailing" secondItem="2Xf-bi-GsJ" secondAttribute="trailing" id="7ue-0C-hFk"/>
-                            <constraint firstItem="2Xf-bi-GsJ" firstAttribute="top" secondItem="O7d-fL-yCf" secondAttribute="top" constant="20" id="GLS-kW-YpY"/>
+                            <constraint firstItem="2Xf-bi-GsJ" firstAttribute="top" secondItem="gry-bT-aQ8" secondAttribute="bottom" constant="8" id="GLS-kW-YpY"/>
                             <constraint firstItem="RmF-vH-boq" firstAttribute="top" secondItem="8d1-bp-e0z" secondAttribute="bottom" id="RBT-o0-S14"/>
                             <constraint firstItem="2Xf-bi-GsJ" firstAttribute="leading" secondItem="O7d-fL-yCf" secondAttribute="leading" id="TcL-AM-y5z"/>
                             <constraint firstItem="RmF-vH-boq" firstAttribute="top" secondItem="8d1-bp-e0z" secondAttribute="bottom" id="Wm1-td-zqZ"/>

--- a/ios/RocketRides/LocationSearchViewController.swift
+++ b/ios/RocketRides/LocationSearchViewController.swift
@@ -33,7 +33,10 @@ class LocationSearchViewController: UIViewController, UITableViewDataSource, UIT
 
         let searchBarFont = UIFont.systemFont(ofSize: 17.0)
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).font = searchBarFont
-        UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).defaultTextAttributes = [NSFontAttributeName: searchBarFont, NSForegroundColorAttributeName: UIColor.riderDarkBlueColor]
+        UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).defaultTextAttributes = [
+            NSAttributedString.Key.font: searchBarFont,
+            NSAttributedString.Key.foregroundColor: UIColor.riderDarkBlueColor
+        ]
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -135,14 +138,14 @@ class LocationSearchViewController: UIViewController, UITableViewDataSource, UIT
         }
 
         // Setup search request
-        let searchRequest = MKLocalSearchRequest()
+        let searchRequest = MKLocalSearch.Request()
 
         searchRequest.naturalLanguageQuery = searchQuery
 
         if let centerCoordinate = delegate?.searchCenterCoordinate(for: self) {
             // Attach region to search request
             let distance: CLLocationDistance = 100 // 100km
-            searchRequest.region = MKCoordinateRegionMakeWithDistance(centerCoordinate, distance, distance)
+            searchRequest.region = MKCoordinateRegion(center: centerCoordinate, latitudinalMeters: distance, longitudinalMeters: distance)
         }
 
         // Perform new search request

--- a/ios/RocketRides/MainAPIClient.swift
+++ b/ios/RocketRides/MainAPIClient.swift
@@ -9,7 +9,7 @@
 import Alamofire
 import Stripe
 
-class MainAPIClient: NSObject, STPEphemeralKeyProvider {
+class MainAPIClient: NSObject, STPCustomerEphemeralKeyProvider {
 
     static let shared = MainAPIClient()
 

--- a/ios/RocketRides/RocketPathOverlay.swift
+++ b/ios/RocketRides/RocketPathOverlay.swift
@@ -19,7 +19,7 @@ class RocketPathOverlay: NSObject, MKOverlay {
         let centerX = boundingMapRect.origin.x + (boundingMapRect.size.width / 2.0)
         let centerY = boundingMapRect.origin.y + (boundingMapRect.size.height / 2.0)
 
-        return MKCoordinateForMapPoint(MKMapPoint(x: centerX, y: centerY))
+        return MKMapPoint(x: centerX, y: centerY).coordinate
     }
 
     var boundingMapRect: MKMapRect {
@@ -28,13 +28,13 @@ class RocketPathOverlay: NSObject, MKOverlay {
         let rect = MKMapRect(origin: origin, size: size)
 
         // Increase rect to accommodate rocket path arc
-        return MKMapRectInset(rect, -size.width, -size.height)
+        return rect.insetBy(dx: -size.width, dy: -size.height)
     }
 
 
     init(start: CLLocationCoordinate2D, end: CLLocationCoordinate2D) {
-        self.startPoint = MKMapPointForCoordinate(start)
-        self.endPoint = MKMapPointForCoordinate(end)
+        self.startPoint = MKMapPoint(start)
+        self.endPoint = MKMapPoint(end)
     }
 
 }

--- a/server/models/passenger.js
+++ b/server/models/passenger.js
@@ -28,7 +28,7 @@ PassengerSchema.methods.displayName = function() {
 PassengerSchema.statics.getLatest = async function() {
   try {
     // Count all the passengers.
-    const count = await Passenger.count().exec();
+    const count = await Passenger.countDocuments().exec();
     if (count === 0) {
       // Create default passengers.
       await Passenger.insertDefaultPassengers();
@@ -46,7 +46,7 @@ PassengerSchema.statics.getLatest = async function() {
 PassengerSchema.statics.getRandom = async function() {
   try {
     // Count all the passengers.
-    const count = await Passenger.count().exec();
+    const count = await Passenger.countDocuments().exec();
     if (count === 0) {
       // Create default passengers.
       await Passenger.insertDefaultPassengers();

--- a/server/models/ride.js
+++ b/server/models/ride.js
@@ -18,8 +18,8 @@ const RideSchema = new Schema({
   currency: { type: String, default: 'usd' },
   created: { type: Date, default: Date.now },
 
-  // Stripe charge ID corresponding to this ride.
-  stripeChargeId: String
+  // Stripe Payment Intent ID corresponding to this ride.
+  stripePaymentIntentId: String
 });
 
 // Return the ride amount for the pilot after collecting 20% platform fees.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/babel-types": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.6.tgz",
-      "integrity": "sha512-8zYZyy2kgwBXdz2j8Ix7LOghGiZbOiHf6vqmmBX1r76FdAzVNv7cODyJTEglUWiOdRnXh0s/o58neUwv5vaitQ=="
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
+      "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
     },
     "@types/babylon": {
       "version": "6.16.5",
@@ -18,25 +18,25 @@
       }
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
         },
         "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.40.0"
           }
         }
       }
@@ -106,11 +106,11 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "asynckit": {
@@ -175,25 +175,25 @@
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "bluebird": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-      "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
       },
       "dependencies": {
         "debug": {
@@ -210,21 +210,21 @@
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
     "bson": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-      "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
     },
     "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -296,9 +296,12 @@
       }
     },
     "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "content-type": {
       "version": "1.0.4",
@@ -330,6 +333,14 @@
         "safe-buffer": "5.1.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -352,9 +363,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -370,11 +381,18 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decamelize": {
@@ -427,9 +445,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -437,68 +455,46 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "express": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
-        "qs": "6.5.1",
-        "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
-            "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
-            "qs": "6.5.1",
-            "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
-          }
-        },
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        },
-        "content-type": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
         },
         "debug": {
           "version": "2.6.9",
@@ -513,97 +509,10 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "requires": {
-            "mime-db": "~1.33.0"
-          }
-        },
         "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "raw-body": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-              "requires": {
-                "depd": "1.1.1",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
-              }
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        },
-        "type-is": {
-          "version": "1.6.16",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "~2.1.18"
-          }
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -636,16 +545,16 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
@@ -656,11 +565,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -725,14 +629,15 @@
       }
     },
     "http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
       },
       "dependencies": {
         "depd": {
@@ -753,9 +658,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -766,9 +671,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -860,9 +765,9 @@
       }
     },
     "kareem": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
-      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
     "keygrip": {
       "version": "1.0.2",
@@ -886,11 +791,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "longest": {
       "version": "1.0.1",
@@ -919,9 +819,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.38.0",
@@ -937,53 +837,54 @@
       }
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
-      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.7.tgz",
+      "integrity": "sha512-2YdWrdf1PJgxcCrT1tWoL6nHuk6hCxhddAAaEh8QJL231ci4+P9FLyqopbTm2Z2sAU6mhCri+wd9r1hOcHdoMw==",
       "requires": {
-        "mongodb-core": "3.1.11",
+        "mongodb-core": "3.2.7",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
-      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.7.tgz",
+      "integrity": "sha512-WypKdLxFNPOH/Jy6i9z47IjG2wIldA54iDZBmHMINcgKOUcWJh8og+Wix76oGd7EyYkHJKssQ2FAOw5Su/n4XQ==",
       "requires": {
-        "bson": "^1.1.0",
+        "bson": "^1.1.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
     },
     "mongoose": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.14.tgz",
-      "integrity": "sha512-lAISH4xdx0/o0bVWPB4bxApP3bA1b08oHPEjTBq3/mIr4R494hepDJJowByBgpGYf8tj/oe6VkFCx8wbRcOciA==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.6.11.tgz",
+      "integrity": "sha512-+Mxfmu2Jcspmdqk1111BLUj5mzSLHWKVovImkjzO9GMymTwkHshsuSFmUN7ou4dWy2WR8DPSJcwU52HhnnNk8Q==",
       "requires": {
-        "async": "2.6.1",
-        "bson": "~1.1.0",
-        "kareem": "2.3.0",
-        "mongodb": "3.1.13",
-        "mongodb-core": "3.1.11",
+        "async": "2.6.2",
+        "bson": "~1.1.1",
+        "kareem": "2.3.1",
+        "mongodb": "3.2.7",
+        "mongodb-core": "3.2.7",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.5.1",
-        "mquery": "3.2.0",
-        "ms": "2.1.1",
-        "regexp-clone": "0.0.1",
+        "mpath": "0.6.0",
+        "mquery": "3.2.1",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
         "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
         "sliced": "1.0.1"
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1020,26 +921,29 @@
       }
     },
     "mpath": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
-      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
+      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
     },
     "mquery": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.0.tgz",
-      "integrity": "sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.1.tgz",
+      "integrity": "sha512-kY/K8QToZWTTocm0U+r8rqcJCp5PRl6e8tPmoDs5OeSO3DInZE2rAL6AYH+V406JTo8305LdASOQcxRDqHojyw==",
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
-        "regexp-clone": "0.0.1",
+        "regexp-clone": "^1.0.0",
         "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1049,9 +953,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -1077,14 +981,14 @@
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
-      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -1132,12 +1036,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.6.0"
+        "ipaddr.js": "1.9.0"
       }
     },
     "psl": {
@@ -1146,118 +1050,118 @@
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "pug": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz",
-      "integrity": "sha1-ccuoJTfJWl6rftBGluQiH1Oqh44=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
       "requires": {
-        "pug-code-gen": "^2.0.1",
-        "pug-filters": "^3.1.0",
-        "pug-lexer": "^4.0.0",
-        "pug-linker": "^3.0.5",
-        "pug-load": "^2.0.11",
-        "pug-parser": "^5.0.0",
-        "pug-runtime": "^2.0.4",
-        "pug-strip-comments": "^1.0.3"
+        "pug-code-gen": "^2.0.2",
+        "pug-filters": "^3.1.1",
+        "pug-lexer": "^4.1.0",
+        "pug-linker": "^3.0.6",
+        "pug-load": "^2.0.12",
+        "pug-parser": "^5.0.1",
+        "pug-runtime": "^2.0.5",
+        "pug-strip-comments": "^1.0.4"
       }
     },
     "pug-attrs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.3.tgz",
-      "integrity": "sha1-owlflw5kFR972tlX7vVftdeQXRU=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
+      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
       "requires": {
         "constantinople": "^3.0.1",
         "js-stringify": "^1.0.1",
-        "pug-runtime": "^2.0.4"
+        "pug-runtime": "^2.0.5"
       }
     },
     "pug-code-gen": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.1.tgz",
-      "integrity": "sha1-CVHsgyJddNjPxHan+Zolm199BQw=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
+      "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
       "requires": {
-        "constantinople": "^3.0.1",
+        "constantinople": "^3.1.2",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.1",
-        "pug-attrs": "^2.0.3",
-        "pug-error": "^1.3.2",
-        "pug-runtime": "^2.0.4",
+        "pug-attrs": "^2.0.4",
+        "pug-error": "^1.3.3",
+        "pug-runtime": "^2.0.5",
         "void-elements": "^2.0.1",
         "with": "^5.0.0"
       }
     },
     "pug-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
-      "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
+      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
     },
     "pug-filters": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz",
-      "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
+      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
       "requires": {
         "clean-css": "^4.1.11",
         "constantinople": "^3.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7",
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8",
         "resolve": "^1.1.6",
         "uglify-js": "^2.6.1"
       }
     },
     "pug-lexer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.0.0.tgz",
-      "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
+      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
       "requires": {
         "character-parser": "^2.1.1",
         "is-expression": "^3.0.0",
-        "pug-error": "^1.3.2"
+        "pug-error": "^1.3.3"
       }
     },
     "pug-linker": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.5.tgz",
-      "integrity": "sha1-npp65ABWgtAn3uuWsAD4juuDoC8=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
+      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
       "requires": {
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7"
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8"
       }
     },
     "pug-load": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.11.tgz",
-      "integrity": "sha1-5kjlftET/iwfRdV4WOorrWvAFSc=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
+      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
       "requires": {
         "object-assign": "^4.1.0",
-        "pug-walk": "^1.1.7"
+        "pug-walk": "^1.1.8"
       }
     },
     "pug-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.0.tgz",
-      "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
+      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
       "requires": {
-        "pug-error": "^1.3.2",
+        "pug-error": "^1.3.3",
         "token-stream": "0.0.1"
       }
     },
     "pug-runtime": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
-      "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
+      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
     },
     "pug-strip-comments": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.3.tgz",
-      "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
+      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
       "requires": {
-        "pug-error": "^1.3.2"
+        "pug-error": "^1.3.3"
       }
     },
     "pug-walk": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
-      "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
+      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -1270,18 +1174,18 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
     },
@@ -1291,9 +1195,9 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regexp-clone": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
-      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1366,9 +1270,9 @@
       }
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -1397,23 +1301,23 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saslprep": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
-      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -1422,12 +1326,12 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -1436,6 +1340,13 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
         "depd": {
@@ -1443,44 +1354,33 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
     },
     "sliced": {
       "version": "1.0.1",
@@ -1528,20 +1428,17 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stripe": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-4.23.1.tgz",
-      "integrity": "sha1-31KXcyPT7oh6B6xZBXA/zcBF0u4=",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.8.0.tgz",
+      "integrity": "sha512-Tmq0xB68W2e4m1FCHLly1dr6SXg+m4cXKhN77NCRkiefaetq/H2+8jDKYerY63Otd6fsRmWTVjuqy+NfUkVVwQ==",
       "requires": {
-        "bluebird": "^2.10.2",
-        "lodash.isplainobject": "^4.0.6",
-        "object-assign": "^4.1.0",
-        "qs": "~6.0.4"
+        "qs": "^6.6.0"
       },
       "dependencies": {
         "qs": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.4.tgz",
-          "integrity": "sha1-UQGdhHIMk5uCc36EVWp4Izjs6ns="
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+          "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
         }
       }
     },
@@ -1549,6 +1446,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "token-stream": {
       "version": "0.0.1",
@@ -1577,25 +1479,25 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "~2.1.24"
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
         },
         "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.40.0"
           }
         }
       }

--- a/server/package.json
+++ b/server/package.json
@@ -17,20 +17,20 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.18.3",
+    "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-beta.3",
-    "debug": "^3.1.0",
-    "express": "^4.16.3",
+    "debug": "^4.1.1",
+    "express": "^4.17.1",
     "express-flash": "0.0.2",
-    "moment": "^2.21.0",
-    "mongoose": "^5.4.14",
+    "moment": "^2.24.0",
+    "mongoose": "^5.6.11",
     "morgan": "^1.9.1",
-    "passport": "^0.3.2",
+    "passport": "^0.4.0",
     "passport-local": "^1.0.0",
-    "pug": "^2.0.3",
+    "pug": "^2.0.4",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "stripe": "^4.23.0"
+    "stripe": "^7.8.0"
   }
 }

--- a/server/routes/api/rides.js
+++ b/server/routes/api/rides.js
@@ -25,7 +25,7 @@ router.post('/', async (req, res, next) => {
    * are securely computed on the backend to make sure the user can't change
    * the payment amount from their web browser or client-side environment.
    */
-  const {source, amount, currency} = req.body;
+  const {paymentMethod, amount, currency} = req.body;
 
   try {
     // For the purpose of this demo, we'll assume we are automatically
@@ -43,9 +43,8 @@ router.post('/', async (req, res, next) => {
     // Save the ride
     await ride.save();
 
-    // Create a charge and set its destination to the pilot's account
-    const charge = await stripe.charges.create({
-      source: source,
+    // Create a Payment Intent and set its destination to the pilot's account
+    const paymentIntent = await stripe.paymentIntents.create({
       amount: ride.amount,
       currency: ride.currency,
       description: config.appName,
@@ -55,13 +54,13 @@ router.post('/', async (req, res, next) => {
         // Send the amount for the pilot after collecting a 20% platform fee:
         // the `amountForPilot` method simply computes `ride.amount * 0.8`
         amount: ride.amountForPilot(),
-        // The destination of this charge is the pilot's Stripe account
+        // The destination of this Payment Intent is the pilot's Stripe account
         destination: pilot.stripeAccountId,
       },
     });
 
-    // Add the Stripe charge reference to the ride and save it
-    ride.stripeChargeId = charge.id;
+    // Add the Stripe Payment Intent reference to the ride and save it
+    ride.stripePaymentIntentId = paymentIntent.id;
     ride.save();
 
     // Return the ride info

--- a/server/routes/api/rides.js
+++ b/server/routes/api/rides.js
@@ -33,6 +33,11 @@ router.post('/', async (req, res, next) => {
     const pilot = await Pilot.getFirstOnboarded();
     // Find the latest passenger (see note above)
     const passenger = await Passenger.getLatest();
+
+    if(!pilot || !passenger) {
+      throw `Could not get ${!pilot ? "pilot" : "passenger"} details.`
+    }
+
     // Create a new ride
     const ride = new Ride({
       pilot: pilot.id,
@@ -71,7 +76,7 @@ router.post('/', async (req, res, next) => {
     });
   } catch (err) {
     res.sendStatus(500);
-    next(`Error adding token to customer: ${err.message}`);
+    next(`Error adding token to customer: ${err.message || err}`);
   }
 });
 


### PR DESCRIPTION
This PR:

- Updates the iOS app to use Swift 4.2, a version of Swift still supported by the current Xcode version (10.3)
- Upgrades the Stripe Cocoapod dependency in the app
- Upgrades Node dependencies in the server
- Switches from using the Sources API to using the PaymentIntents api
- Provides a better error message on `/api/rides` when the pilot or passenger objects don't exist
- Changes the Mongoose function used to count passengers (`collection.count` is deprecated)
- Updates the Readme to reduce a point of confusion I ran into while setting up my own integration