### PR TITLE
Fix setTimeout call so an error isn't thrown when a connection is lost

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -26,7 +26,7 @@ const connectRetry = function() {
   }, (err) => {
     if (err) {
       console.log('Mongoose connection error:', err);
-      setTimeout(5000, connectRetry);
+      setTimeout(connectRetry, 5000);
     }
   });
 }


### PR DESCRIPTION
As the title implies, currently if a connection is lost an error is thrown:

```
(node:15719) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received 5000
```

Expected behavior is that a connection is retried on a 5s interval. 