### PR TITLE
Update Node version to 12

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -1,6 +1,6 @@
 # Configuration for Node in App Engine standard on Google Cloud Platform.
 
-runtime: nodejs10
+runtime: nodejs12
 instance_class: F1
 
 handlers:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,7 +27,7 @@
         "stripe": "^7.8.0"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/stripe/stripe-connect-rocketrides.git"
   },
   "engines": {
-    "node": ">=10.0"
+    "node": ">=12.0"
   },
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
Mongoose v6 requires Node 12 or higher. Updating the version in package.json and app.yaml.

https://stackoverflow.com/questions/69015811/referenceerror-textencoder-is-not-defined-node-js-with-mongoose