### PR TITLE
Add Stripe API version to config

### DIFF
--- a/server/config.default.js
+++ b/server/config.default.js
@@ -18,7 +18,8 @@ module.exports = {
   // Connect Settings: https://dashboard.stripe.com/account/applications/settings
   stripe: {
     secretKey: 'YOUR_STRIPE_SECRET_KEY',
-    publishableKey: 'YOUR_STRIPE_PUBLISHABLE_KEY'
+    publishableKey: 'YOUR_STRIPE_PUBLISHABLE_KEY',
+    apiVersion: '2022-08-01'
   },
 
   // Configuration for MongoDB

--- a/server/models/passenger.js
+++ b/server/models/passenger.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const config = require('../config');
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = require('stripe')(config.stripe.secretKey, {
+  apiVersion: config.stripe.apiVersion || '2022-08-01'
+});
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 

--- a/server/routes/api/passengers.js
+++ b/server/routes/api/passengers.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const config = require('../../config');
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = require('stripe')(config.stripe.secretKey, {
+  apiVersion: config.stripe.apiVersion || '2022-08-01'
+});
 const express = require('express');
 const router = express.Router();
 const Passenger = require('../../models/passenger');

--- a/server/routes/api/rides.js
+++ b/server/routes/api/rides.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const config = require('../../config');
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = require('stripe')(config.stripe.secretKey, {
+  apiVersion: config.stripe.apiVersion || '2022-08-01'
+});
 const express = require('express');
 const router = express.Router();
 const Pilot = require('../../models/pilot');

--- a/server/routes/pilots/pilots.js
+++ b/server/routes/pilots/pilots.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const config = require('../../config');
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = require('stripe')(config.stripe.secretKey, {
+  apiVersion: config.stripe.apiVersion || '2022-08-01'
+});
 const express = require('express');
 const router = express.Router();
 const passport = require('passport');

--- a/server/routes/pilots/stripe.js
+++ b/server/routes/pilots/stripe.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const config = require('../../config');
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = require('stripe')(config.stripe.secretKey, {
+  apiVersion: config.stripe.apiVersion || '2022-08-01'
+});
 const request = require('request-promise-native');
 const querystring = require('querystring');
 const express = require('express');


### PR DESCRIPTION
Adds Stripe API version to the config file. All Stripe calls are pinned to this API version, with the default being 2022-08-01 if not set.