### PR TITLE
Fix germany for the rocketrides.io demo

### DIFF
--- a/server/routes/pilots/pilots.js
+++ b/server/routes/pilots/pilots.js
@@ -90,8 +90,8 @@ router.post('/rides', pilotRequired, async (req, res, next) => {
       source = getTestSource('payout_limit');
     }
     let charge;
-    // Accounts created in Japan have the `full` service agreement and must create their own card payments
-    if (pilot.country === 'JP') {
+    // Accounts created in Japan/Germany have the `full` service agreement and must create their own card payments
+    if (pilot.country === 'JP' || pilot.country === 'DE') {
       // Create a Destination Charge to the pilot's account
       charge = await stripe.charges.create({
         source: source,


### PR DESCRIPTION
The create payment step was broken for Germany and required a similar fix to Japan:
Before:
<img width="409" alt="image" src="https://github.com/stripe/stripe-connect-rocketrides/assets/95381655/4eb410b1-5964-4b70-bd52-c18d9cf782bb">
After:
<img width="1490" alt="image" src="https://github.com/stripe/stripe-connect-rocketrides/assets/95381655/f80fe5db-8835-450a-b064-69af0a3d9e99">
